### PR TITLE
Debug while

### DIFF
--- a/src/mate_clj/core.clj
+++ b/src/mate_clj/core.clj
@@ -156,3 +156,12 @@
   ([pred] (dfilter (complement pred)))
   ([pred coll]
    (dfilter (complement pred) coll)))
+
+
+(defmacro dwhile
+  [test & body]
+  `(loop []
+     (println ~@test "=>" ~test)
+     (when ~test
+       ~@body
+       (recur))))

--- a/src/mate_clj/core.clj
+++ b/src/mate_clj/core.clj
@@ -157,7 +157,6 @@
   ([pred coll]
    (dfilter (complement pred) coll)))
 
-<<<<<<< HEAD
 (defn dtake-while
   ([pred]
    (fn [rf]

--- a/src/mate_clj/core.clj
+++ b/src/mate_clj/core.clj
@@ -202,3 +202,11 @@
 (defn dsplit-with
   [pred coll]
   [(dtake-while pred coll) (ddrop-while pred coll)])
+
+(defmacro dwhile
+  [test & body]
+  `(loop []
+     (println ~@test "=>" ~test)
+     (when ~test
+       ~@body
+       (recur))))

--- a/src/mate_clj/core.clj
+++ b/src/mate_clj/core.clj
@@ -206,7 +206,7 @@
 (defmacro dwhile
   [test & body]
   `(loop []
-     (println ~@test "=>" ~test)
+     (println '~test "=>" ~test)
      (when ~test
        ~@body
        (recur))))


### PR DESCRIPTION
Hi,

this code works partially:
first define atom : (def a (atom 10))
working example : (dwhile (pos? @a) (do (println @a) (swap! a dec)))
not working example: (dwhile (or (pos? @a) (not (neg? @a))) (do (println @a) (swap! a dec)))
this is the error ==> CompilerException java.lang.RuntimeException: Can't take value of a macro: #'clojure.core/or, compiling:(null:1:1) the cause is that or is a macro and not a function.
do you have an idea how to workaround this issue ?
Thanks.