### PR TITLE
fixed: mate-clj.core/arrow-str is not public

### DIFF
--- a/src/mate_clj/core.clj
+++ b/src/mate_clj/core.clj
@@ -128,7 +128,7 @@
   [expr name & clauses]
   (let [c (gensym) s (gensym) t (gensym)]
     `(let [~name ~expr]
-       (println '~name arrow-str ~expr)
+       (println '~name ~arrow-str ~expr)
        (loop [~name ~expr, ~c '~clauses]
          (if ~c
            (let [~s (first ~c)
@@ -138,7 +138,7 @@
                         (= ~s '~name)
                         ~name
                         ~s))]
-             (println ~s arrow-str (eval ~t))
+             (println ~s ~arrow-str (eval ~t))
              (recur (eval ~t) (next ~c)))
           ~name)))))
 

--- a/test/mate_clj/core_test.clj
+++ b/test/mate_clj/core_test.clj
@@ -5,3 +5,14 @@
 (deftest a-test
   (testing "FIXME, I fail."
     (is (= 0 1))))
+
+(deftest das-test
+  (testing "das->"
+    (is (= (as-> 1 n
+             (* 2 n)
+             (+ n n)
+             (+ n 2 3 4))
+           (das-> 1 n
+                  (* 2 n)
+                  (+ n n)
+                  (+ n 2 3 4))))))


### PR DESCRIPTION
Hello, I got some error messages and fixed from das-> function.

`Syntax error (IllegalStateException) compiling at (core_test.clj:15:12).
var: mate-clj.core/arrow-str is not public`